### PR TITLE
DFS code in Java was not working

### DIFF
--- a/DfsJava
+++ b/DfsJava
@@ -48,8 +48,8 @@ class Solution
     public ArrayList<Integer> dfsOfGraph(int V, ArrayList<ArrayList<Integer>> adj)
     {
         ArrayList<Integer> storeDfs = new ArrayList<>(); 
-        boolean vis[] = new boolean[V+1]; 
-        for(int i = 1;i<=V;i++) {
+        boolean vis[] = new boolean[V]; 
+        for(int i = 0;i<V;i++) {
             if(!vis[i]) dfs(i, vis, adj, storeDfs); 
         }
         


### PR DESCRIPTION
The way the input was taken was for a graph which started from 0, put the way the graph was being traversed with dfs was with the fact that the graph starts from 1. To fix, I have changed the way the where to where the iterator runs, so that the graph works as a 0 node starting graph. It works properly now.

Sample Input/Output after fix:
```
1
7 6
0 1
1 3
1 6
6 5
3 5
2 4
0 1 3 5 6 2 4 
```